### PR TITLE
Add message reader to package

### DIFF
--- a/src/Amido.Stacks.Messaging.Azure.EventHub.Tests/EventConsumerTest.cs
+++ b/src/Amido.Stacks.Messaging.Azure.EventHub.Tests/EventConsumerTest.cs
@@ -1,9 +1,0 @@
-﻿using Xunit;
-
-namespace Amido.Stacks.Messaging.Azure.EventHub.Tests
-{
-    public class EventConsumerTest
-    {
-
-    }
-}

--- a/src/Amido.Stacks.Messaging.Azure.EventHub.Tests/EventPublisherTest.cs
+++ b/src/Amido.Stacks.Messaging.Azure.EventHub.Tests/EventPublisherTest.cs
@@ -1,9 +1,0 @@
-﻿using Xunit;
-
-namespace Amido.Stacks.Messaging.Azure.EventHub.Tests
-{
-    public class EventPublisherTest
-    {
-
-    }
-}

--- a/src/Amido.Stacks.Messaging.Azure.EventHub.Tests/Serializers/JsonMessageSerializerTests.cs
+++ b/src/Amido.Stacks.Messaging.Azure.EventHub.Tests/Serializers/JsonMessageSerializerTests.cs
@@ -1,0 +1,34 @@
+﻿using Amido.Stacks.Application.CQRS.Events;
+using Amido.Stacks.Messaging.Azure.EventHub.Serializers;
+using Microsoft.Azure.EventHubs;
+using Newtonsoft.Json;
+using Shouldly;
+using System;
+using System.Text;
+using Xunit;
+
+namespace Amido.Stacks.Messaging.Azure.EventHub.Tests.Serializers
+{
+    public class JsonMessageSerializerTests
+    {
+        [Fact]
+        public void GivenTheParametersCorrectTheBodyOfTheApplicationEventWillBeParsed()
+        {
+            // Arrange
+            var parser = new JsonMessageSerializer();
+            var correlationId = Guid.NewGuid();
+            var menuCreatedEvent = new MenuCreatedEvent(101, correlationId, new Guid("C8A14B73F2A14696BEEFBD432AF27296"));
+            var jsonString = JsonConvert.SerializeObject(menuCreatedEvent);
+            var byteArray = Encoding.UTF8.GetBytes(jsonString);
+            var eventData = new EventData(byteArray);
+
+            // Act
+            var result = parser.Read<MenuCreatedEvent>(eventData);
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldBeOfType(typeof(MenuCreatedEvent));
+            result.CorrelationId.ShouldBe(correlationId);
+        }
+    }
+}

--- a/src/Amido.Stacks.Messaging.Azure.EventHub/Amido.Stacks.Messaging.Azure.EventHub.csproj
+++ b/src/Amido.Stacks.Messaging.Azure.EventHub/Amido.Stacks.Messaging.Azure.EventHub.csproj
@@ -5,15 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Amido.Stacks.Application.CQRS.Events" Version="0.2.10" />
     <PackageReference Include="Amido.Stacks.Configuration" Version="0.2.18" />
     <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.17" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.6.0" />
     <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.6.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />

--- a/src/Amido.Stacks.Messaging.Azure.EventHub/Serializers/IMessageReader.cs
+++ b/src/Amido.Stacks.Messaging.Azure.EventHub/Serializers/IMessageReader.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Azure.EventHubs;
+
+namespace Amido.Stacks.Messaging.Azure.EventHub.Serializers
+{
+    public interface IMessageReader
+    {
+        T Read<T>(EventData eventData);
+    }
+}

--- a/src/Amido.Stacks.Messaging.Azure.EventHub/Serializers/JsonMessageSerializer.cs
+++ b/src/Amido.Stacks.Messaging.Azure.EventHub/Serializers/JsonMessageSerializer.cs
@@ -1,0 +1,15 @@
+﻿using System.Text;
+using Microsoft.Azure.EventHubs;
+using Newtonsoft.Json;
+
+namespace Amido.Stacks.Messaging.Azure.EventHub.Serializers
+{
+    public class JsonMessageSerializer : IMessageReader
+    {
+        public T Read<T>(EventData eventData)
+        {
+            var jsonBody = Encoding.UTF8.GetString(eventData.Body.Array);
+            return JsonConvert.DeserializeObject<T>(jsonBody);
+        }
+    }
+}


### PR DESCRIPTION
Add message reader to Event Hub nuget package

#### 📲 What

Add the json message serializer into the package.

#### 🤔 Why
		
This is used in the Event Hub listener to parse messages from json to an object.
		
#### 🛠 How
		
More in-depth discussion of the change or implementation.

#### 👀 Evidence
		
Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR
		 
#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
