### PR TITLE
fix: Updates the default branch for packages

### DIFF
--- a/build/azDevOps/packages-amido-stacks-messaging-aeh.yml
+++ b/build/azDevOps/packages-amido-stacks-messaging-aeh.yml
@@ -92,7 +92,7 @@ stages:
             parameters:
               sourcebranch_name: "$(Build.SourceBranchName)"
               raw_version_number: "$(Version.Number)"
-              default_branch: 'main'
+              default_branch: 'master'
 
           # Validates all YAML files in the repo to check they adhere to standards
           - template: azDevOps/azure/templates/v3/steps/build/test-validate-yaml.yml@templates


### PR DESCRIPTION
The default branch is master on this repo, and without it the packages _always_ come out as preview